### PR TITLE
Fix from_yaml_file() 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "navdict"
-version = "0.2.2"
+version = "0.2.3"
 description = "A navigable dictionary with dot notation access and automatic file loading"
 readme = "README.md"
 authors = [

--- a/tests/test_navdict.py
+++ b/tests/test_navdict.py
@@ -211,3 +211,19 @@ def test_int_enum():
     assert isinstance(setup.F_FEE.ccd_sides.enum, get_enum_metaclass())
     assert isinstance(setup.F_FEE.ccd_sides.enum, type)
     assert isinstance(setup.F_FEE.ccd_sides.enum.E, enum.IntEnum)  # noqa
+
+
+YAML_STRING_LOADS_YAML_FILE = """
+root:
+    simple: yaml//enum.yaml
+"""
+
+
+def test_recursive_load():
+
+    with (
+        create_text_file("load_yaml.yaml", YAML_STRING_LOADS_YAML_FILE) as fn,
+        create_text_file("enum.yaml", YAML_STRING_WITH_INT_ENUM)
+    ):
+        data = navdict.from_yaml_file(fn)
+        assert data.root.simple.F_FEE.ccd_sides.enum.E.value == 1

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "navdict"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
- A previous pull request introduced a bug in the method `.from_yaml_file()`, this is now resolved.
- I also added unit test for the `int_enum` directive and for recursive loading a YAML file.