### PR TITLE
cleanup getattribute and getitem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ wheels/
 .venv
 
 # IDE
-
 .idea/
+
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "navdict"
-version = "0.2.4"
+version = "0.2.5"
 description = "A navigable dictionary with dot notation access and automatic file loading"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ testpaths = [
     "tests",
 ]
 addopts = "-rA --cov --cov-branch --cov-report html"
+log_cli = true
+log_cli_level = "INFO"
+filterwarnings = [
+    "ignore::DeprecationWarning"
+]
+
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_navdict.py
+++ b/tests/test_navdict.py
@@ -20,6 +20,14 @@ class TakeTwoOptionalArguments:
         return f"a={self._a}, b={self._b}"
 
 
+class TakeOneKeywordArgument:
+    def __init__(self, *, sim: bool):
+        self._sim = sim
+
+    def __str__(self):
+        return f"sim = {self._sim}"
+
+
 YAML_STRING_SIMPLE = """
 Setup:
     site_id: KUL
@@ -37,6 +45,10 @@ root:
     with_args:
         dev: class//test_navdict.TakeTwoOptionalArguments
         dev_args: [42, 73]
+    with_kwarg:
+        dev: class//test_navdict.TakeOneKeywordArgument
+        dev_kwargs:
+            sim: true
 """
 
 YAML_STRING_WITH_INT_ENUM = """
@@ -154,6 +166,10 @@ def test_class_directive():
     assert isinstance(obj, TakeTwoOptionalArguments)
     assert str(obj) == "a=42, b=73"
 
+    obj = setup.root.with_kwarg.dev
+    assert isinstance(obj, TakeOneKeywordArgument)
+    assert str(obj) == "sim = True"
+
 
 def test_from_dict():
 
@@ -233,7 +249,7 @@ def test_recursive_load():
 YAML_STRING_LOADS_CSV_FILE = """
 root:
     sample: csv//sample.csv
-    kwargs:
+    sample_kwargs:
         header_rows: 2
 """
 

--- a/uv.lock
+++ b/uv.lock
@@ -134,7 +134,7 @@ wheels = [
 
 [[package]]
 name = "navdict"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
There was common code in `__getattribute__` and `__getitem__` that was already diverging. That is now fixed in a new private method used by both under functions. Additionally, we fixed the args and kwargs for directives.