### PR TITLE
handle `~` in the filename provided by `navdict.from_yaml_file(...)` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "navdict"
-version = "0.3.0"
+version = "0.3.1"
 description = "A navigable dictionary with dot notation access and automatic file loading"
 readme = "README.md"
 authors = [

--- a/src/navdict/navdict.py
+++ b/src/navdict/navdict.py
@@ -662,6 +662,11 @@ class NavigableDict(dict):
         if not filename:
             raise ValueError("Invalid argument to function: No filename or None given.")
 
+        # Make sure the filename exists and is a regular file
+        filename = Path(filename).expanduser().resolve()
+        if not filename.is_file():
+            raise ValueError(f"Invalid argument to function, filename does not exist: {filename!s}")
+
         data = _load_yaml(str(filename))
 
         if data == {}:

--- a/tests/test_navdict.py
+++ b/tests/test_navdict.py
@@ -142,6 +142,11 @@ def test_from_yaml_string():
 
 
 def test_from_yaml_file():
+
+    with pytest.raises(ValueError, match=r"Invalid argument to function, filename does not exist: "
+                                         r".*/simple.yaml"):
+        navdict.from_yaml_file("~/simple.yaml")
+
     with create_text_file("simple.yaml", YAML_STRING_SIMPLE) as fn:
         setup = navdict.from_yaml_file(fn)
         assert "Setup" in setup

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "navdict"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
This pull request fixes issue #20 and handles `~` as the user's home folder when passed into `navdict.from_yaml_file(...)`.