### PR TITLE
Fix scanner error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "navdict"
-version = "0.5.1"
+version = "0.5.2"
 description = "A navigable dictionary with dot notation access and automatic file loading"
 readme = "README.md"
 authors = [

--- a/src/navdict/navdict.py
+++ b/src/navdict/navdict.py
@@ -212,6 +212,10 @@ def load_yaml(resource_name: str, parent_location: Path | None = None, *args, **
             exc_info=True,
         )
         raise
+    except ScannerError as exc:
+        msg = f"A error occurred while scanning the YAML file: {yaml_location / fn}."
+        logger.error(msg, exc_info=True)
+        raise IOError(msg) from exc
 
     data = NavigableDict(data, _filename=yaml_location / fn)
 

--- a/tests/test_navdict.py
+++ b/tests/test_navdict.py
@@ -437,3 +437,12 @@ def test_non_string_keys():
     assert x.A[1] == "one"
     assert x.A[2] == "two"
     assert x.A[(3,)] == "three-tuple"
+
+
+def test_invalid_yaml():
+
+    # This would normally raise a ScannerError from the ruamel.yaml package
+    #  -  ruamel.yaml.scanner.ScannerError: mapping values are not allowed in this context
+
+    with pytest.raises(IOError):
+        _ = navdict.from_yaml_file(__file__)

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "navdict"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
When reading an invalid YAML file, like `__file__` (Python code), a ScannerError is raised. We catch this and re-raise an IOError with a proper explanation message.
