### PR TITLE
Feature register directive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "navdict"
-version = "0.5.5"
+version = "0.5.6"
 description = "A navigable dictionary with dot notation access and automatic file loading"
 readme = "README.md"
 authors = [

--- a/src/navdict/directive.pyi
+++ b/src/navdict/directive.pyi
@@ -1,10 +1,11 @@
-from dataclasses import dataclass
 from importlib.metadata import EntryPoint
 from typing import Callable
 
-@dataclass
 class Directive:
-    ep: EntryPoint
+    def __init__(self, ep: EntryPoint | None = None, *, name: str | None = None, func: Callable | None = None):
+        self.ep = None
+        self.directive_func = None
+        self.directive_name = None
 
     @property
     def name(self) -> str: ...

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "navdict"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
add a function to register a normal function as a directive function for navdict. You can use the function `register_directive(name, func)` to register a directive. This can also be used to overwrite standard/default plugin directives.