### PR TITLE
Add support for environment variable expansion in csv directive

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -148,3 +148,32 @@ setup:
 
 This will pass `header_rows=2` as a keyword argument into the `load_csv()` 
 directive function.
+
+## Environment variables in the csv directive
+
+The `csv//` directive supports `ENV[VARNAME]` references anywhere in the 
+resource path. Each reference is replaced with the value of the 
+corresponding environment variable before the file is located, and the 
+result is then expanded for a leading `~` (user home directory). The 
+variable name may optionally be wrapped in single or double quotes — 
+`ENV[VARNAME]`, `ENV['VARNAME']` and `ENV["VARNAME"]` are all equivalent.
+
+```yaml
+setup:
+    hk_metrics: csv//ENV[DATA_STORAGE]/hk_metrics_daq.csv
+```
+
+If `DATA_STORAGE` is set to `~/data`, this resolves to 
+`~/data/hk_metrics_daq.csv`, i.e. `/home/<user>/data/hk_metrics_daq.csv`.
+
+If a referenced environment variable is not set, a `ValueError` is raised.
+
+This expansion is enabled by default. To disable it, set `expand_env: false` 
+in the `<key>_kwargs` entry:
+
+```yaml
+setup:
+    hk_metrics: csv//ENV[DATA_STORAGE]/hk_metrics_daq.csv
+    hk_metrics_kwargs:
+        expand_env: false
+```

--- a/src/navdict/navdict.py
+++ b/src/navdict/navdict.py
@@ -38,6 +38,7 @@ import importlib
 import itertools
 import logging
 import os
+import re
 import textwrap
 import warnings
 from enum import IntEnum
@@ -121,13 +122,49 @@ def get_resource_location(parent_location: Path | None, in_dir: str | None) -> P
     return location
 
 
+ENV_VAR_PATTERN = re.compile(r"ENV\[\s*['\"]?(\w+)['\"]?\s*]")
+
+
+def expand_env_vars(value: str) -> str:
+    """
+    Expand `ENV[VARNAME]` references in `value` with the value of the corresponding environment
+    variable, then apply `~` (user) expansion to the result.
+
+    The variable name may optionally be wrapped in single or double quotes, i.e. `ENV[VARNAME]`,
+    `ENV['VARNAME']` and `ENV["VARNAME"]` are all equivalent.
+
+    Args:
+        value: a string that may contain zero or more `ENV[VARNAME]` references.
+
+    Returns:
+        The string with all `ENV[VARNAME]` references expanded and `~` expanded to the user's
+        home directory.
+
+    Raises:
+        ValueError: when a referenced environment variable is not set.
+    """
+
+    def _replace(match: re.Match) -> str:
+        var_name = match[1]
+        try:
+            return os.environ[var_name]
+        except KeyError:
+            raise ValueError(f"Environment variable '{var_name}' referenced in '{value}' is not set.") from None
+
+    return str(Path(ENV_VAR_PATTERN.sub(_replace, value)).expanduser())
+
+
 def load_csv(resource_name: str, parent_location: Path | None, *args, **kwargs) -> list[list[str]]:
     """
     Find and return the content of a CSV file.
 
     If the `resource_name` argument starts with the directive (`csv//`), it will be split off automatically.
-    The `kwargs` dictionary can contain the key `header_rows` which indicates the number of header rows to
-    be skipped when processing the file.
+    The `kwargs` dictionary can contain the following keys:
+
+    - `header_rows`: the number of header rows to skip when processing the file.
+    - `expand_env`: when `True` (the default), `ENV[VARNAME]` references in `resource_name` are expanded
+      with the value of the corresponding environment variable before the file is located. Set to `False`
+      to disable this expansion.
 
     Returns:
         A list of the split lines, i.e. a list of lists of strings.
@@ -140,6 +177,9 @@ def load_csv(resource_name: str, parent_location: Path | None, *args, **kwargs) 
 
     if not resource_name:
         raise ValueError(f"Resource name should not be empty, but contain a valid filename.")
+
+    if kwargs.get("expand_env", True):
+        resource_name = expand_env_vars(resource_name)
 
     parts = resource_name.rsplit("/", 1)
     in_dir, fn = parts if len(parts) > 1 else (None, parts[0])  # use a tuple here to make Mypy happy

--- a/tests/test_navdict.py
+++ b/tests/test_navdict.py
@@ -11,6 +11,7 @@ from navdict.directive import Directive
 from navdict.directive import get_directive_plugin
 from navdict.directive import is_directive
 from navdict.directive import register_directive
+from navdict.navdict import expand_env_vars
 from navdict.navdict import get_resource_location
 
 HERE = Path(__file__).parent
@@ -402,6 +403,88 @@ def test_load_csv():
 
         assert csv_data[0][0] == "1001"
         assert csv_data[0][8] == "john.smith@company.com"
+
+
+def test_expand_env_vars():
+    os.environ["NAVDICT_TEST_VAR"] = "some/value"
+
+    assert expand_env_vars("prefix/ENV[NAVDICT_TEST_VAR]/suffix") == "prefix/some/value/suffix"
+    assert expand_env_vars("prefix/ENV['NAVDICT_TEST_VAR']/suffix") == "prefix/some/value/suffix"
+    assert expand_env_vars('prefix/ENV["NAVDICT_TEST_VAR"]/suffix') == "prefix/some/value/suffix"
+
+    os.environ["NAVDICT_TEST_HOME_VAR"] = "~"
+
+    assert expand_env_vars("ENV[NAVDICT_TEST_HOME_VAR]/data") == str(Path.home() / "data")
+
+    del os.environ["NAVDICT_TEST_VAR"]
+    del os.environ["NAVDICT_TEST_HOME_VAR"]
+
+    with pytest.raises(ValueError):
+        expand_env_vars("ENV[NAVDICT_TEST_VAR_NOT_SET]/data")
+
+
+YAML_STRING_LOADS_CSV_FILE_WITH_ENV_VAR = """
+root:
+    sample: csv//ENV[NAVDICT_TEST_DATA_DIR]/sample.csv
+    sample_kwargs:
+        header_rows: 1
+"""
+
+YAML_STRING_LOADS_CSV_FILE_WITH_ENV_VAR_DISABLED = """
+root:
+    sample: csv//ENV[NAVDICT_TEST_DATA_DIR]/sample.csv
+    sample_kwargs:
+        header_rows: 1
+        expand_env: false
+"""
+
+YAML_STRING_LOADS_CSV_FILE_WITH_MISSING_ENV_VAR = """
+root:
+    sample: csv//ENV[NAVDICT_TEST_VAR_NOT_SET]/sample.csv
+"""
+
+
+def test_load_csv_with_env_var():
+    os.environ["NAVDICT_TEST_DATA_DIR"] = str(HERE / "data")
+
+    try:
+        with (
+            create_text_file(HERE / "load_csv_env.yaml", YAML_STRING_LOADS_CSV_FILE_WITH_ENV_VAR) as fn,
+            create_test_csv_file(HERE / "data/sample.csv"),
+        ):
+            data = navdict.from_yaml_file(fn)
+
+            csv_data = data.root.sample
+
+            assert isinstance(csv_data, list)
+            assert csv_data[0][0] == "1001"
+            assert csv_data[0][8] == "john.smith@company.com"
+    finally:
+        del os.environ["NAVDICT_TEST_DATA_DIR"]
+
+
+def test_load_csv_env_var_expansion_disabled():
+    os.environ["NAVDICT_TEST_DATA_DIR"] = str(HERE / "data")
+
+    try:
+        with (
+            create_text_file(HERE / "load_csv_env_disabled.yaml", YAML_STRING_LOADS_CSV_FILE_WITH_ENV_VAR_DISABLED) as fn,
+            create_test_csv_file(HERE / "data/sample.csv"),
+        ):
+            data = navdict.from_yaml_file(fn)
+
+            with pytest.raises(FileNotFoundError):
+                _ = data.root.sample
+    finally:
+        del os.environ["NAVDICT_TEST_DATA_DIR"]
+
+
+def test_load_csv_missing_env_var():
+    with create_text_file(HERE / "load_csv_missing_env.yaml", YAML_STRING_LOADS_CSV_FILE_WITH_MISSING_ENV_VAR) as fn:
+        data = navdict.from_yaml_file(fn)
+
+        with pytest.raises(ValueError):
+            _ = data.root.sample
 
 
 def test_directive_registration():


### PR DESCRIPTION
Add support for environment variable expansion in csv directive

- Implemented `expand_env_vars` function to replace `ENV[VARNAME]` references with corresponding environment variable values.
- Updated `load_csv` function to optionally disable environment variable expansion via `expand_env` keyword argument.
- Enhanced documentation to explain the usage of environment variables in the csv directive.
- Added tests for environment variable expansion and its handling in YAML configurations.
