### PR TITLE
Fix alias hook exception handling in NavigableDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-16
+
+### Fixed
+
+- Fixed alias hook exception handling in NavigableDict. When an alias still returns an unknown attribute, don't log an error message.
+
 ## [0.9.0] - 2026-07-14
 
 ### Added
@@ -239,7 +245,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial commit.
 
-[Unreleased]: https://github.com/IvS-KULeuven/navdict/compare/0.9.0...HEAD
+---
+
+[Unreleased]: https://github.com/IvS-KULeuven/navdict/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/IvS-KULeuven/navdict/releases/tag/0.10.0
 [0.9.0]: https://github.com/IvS-KULeuven/navdict/releases/tag/0.9.0
 [0.8.0]: https://github.com/IvS-KULeuven/navdict/releases/tag/0.8.0
 [0.7.0]: https://github.com/IvS-KULeuven/navdict/releases/tag/0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "navdict"
-version = "0.9.0"
+version = "0.10.0"
 description = "A navigable dictionary with dot notation access and automatic file loading"
 readme = "README.md"
 authors = [

--- a/src/navdict/navdict.py
+++ b/src/navdict/navdict.py
@@ -484,10 +484,14 @@ class NavigableDict(dict):
             try:
                 alias = self._alias_hook(key)
                 value = object.__getattribute__(self, alias)
-            except NotImplementedError:
+            except (NotImplementedError, AttributeError):
+                # Either the alias hook is not implemented or the alias hook just returned a key that still doesn't exist.
+                # In both cases we want to raise an AttributeError to indicate that the attribute does not exist.
                 raise AttributeError(f"{type(self).__name__!r} object has no attribute {key!r}")
             except Exception as exc:
-                logger.error(f"Alias hook function raised {type(exc).__name__!r}: {exc}")
+                logger.error(
+                    f"Alias hook function {self._alias_hook.__name__!r}({key}) raised {type(exc).__name__!r}: {exc}"
+                )
                 raise AttributeError(f"{type(self).__name__!r} object has no attribute {key!r}")
 
         if key.startswith("__"):  # small optimization
@@ -530,7 +534,9 @@ class NavigableDict(dict):
             except NotImplementedError:
                 raise KeyError(f"{type(self).__name__!r} has no key {key!r}")
             except Exception as exc:
-                logger.error(f"Alias hook function raised {type(exc).__name__!r}: {exc}")
+                logger.error(
+                    f"Alias hook function {self._alias_hook.__name__!r}({key}) raised {type(exc).__name__!r}: {exc}"
+                )
                 raise KeyError(f"{type(self).__name__!r} has no key {key!r}")
 
         if isinstance(key, str) and key.startswith("__"):

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "navdict"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
In IPython, when an object is displayed, IPython probes special method names like `_ipython_display_`, `_repr_mimebundle_`, `_repr_png_`, etc.

For some attributes in `navdict`, an alias hook can be installed to allow accessing attributes with different aliases.  Those probe names from IPython are getting routed through the `navdict` alias hook, so any hook is called with strings like `_repr_png_`. The alias hook can throw an Exception on the unexpected input which results in an error logged by `navdict`.

A real code example:
```
In [4]: setup.camera
Out[4]: 2026-07-16 12:14:57 [   ERROR] Alias hook function '_resolve_camera_name_for_alias_hook'(_ipython_canary_method_should_not_exist_) raised 'AttributeError': 'NavigableDict' object has no attribute '_ipython_canary_method_should_not_exist_' (MainProcess[41572]:n/a:navdict.py:490)
2026-07-16 12:14:57 [   ERROR] Alias hook function '_resolve_camera_name_for_alias_hook'(_ipython_display_) raised 'AttributeError': 'NavigableDict' object has no attribute '_ipython_display_' (MainProcess[41572]:n/a:navdict.py:490)
2026-07-16 12:14:57 [   ERROR] Alias hook function '_resolve_camera_name_for_alias_hook'(_ipython_canary_method_should_not_exist_) raised 'AttributeError': 'NavigableDict' object has no attribute '_ipython_canary_method_should_not_exist_' (MainProcess[41572]:n/a:navdict.py:490)
2026-07-16 12:14:57 [   ERROR] Alias hook function '_resolve_camera_name_for_alias_hook'(_repr_mimebundle_) raised 'AttributeError': 'NavigableDict' object has no attribute '_repr_mimebundle_' (MainProcess[41572]:n/a:navdict.py:490)
2026-07-16 12:14:57 [   ERROR] Alias hook function '_resolve_camera_name_for_alias_hook'(_ipython_canary_method_should_not_exist_) raised 'AttributeError': 'NavigableDict' object has no attribute '_ipython_canary_method_should_not_exist_' (MainProcess[41572]:n/a:navdict.py:490)
2026-07-16 12:14:57 [   ERROR] Alias hook function '_resolve_camera_name_for_alias_hook'(_repr_png_) raised 'AttributeError': 'NavigableDict' object has no attribute '_repr_png_' (MainProcess[41572]:n/a:navdict.py:490)
NavigableDict(<super: <class 'NavigableDict'>, <NavigableDict object>>) [id=4503445952]
```

These messages are not indicating a broken flow. It is IPython introspection colliding with alias-based key resolution.

Extra confirmation: this same pattern happens when the python `rich` package pretty-printing probes mappings with a random canary key (a long gibberish string like `aihwerij235234ljsdnp34ksodfipwoe234234jlskjdf`).

This pull request now properly handles the AttributeError that is thrown without logging an error.

